### PR TITLE
Made postfiles work with Jekyll 0.9.0 and newer

### DIFF
--- a/_plugins/postfiles.rb
+++ b/_plugins/postfiles.rb
@@ -1,4 +1,12 @@
 module Jekyll
+  
+  # StaticFile subclass that properly translates paths
+  class PostFile < StaticFile
+    def path
+      File.join(@base, @name)
+    end
+  end
+
   class Postfiles < Generator
     safe true
     priority :lowest
@@ -14,13 +22,12 @@ module Jekyll
         # Go back to the single-file post name
         postfile_id = post.id.gsub(/(\d{4})\/(\d\d)\/(\d\d)\/(.*)/, '\1-\2-\3-\4')
         # Get the directory that files from this post would be in
-        postfile_dir = File.join('./_postfiles', postfile_id)
-        # Next post if there aren't any postfiles for this post
-        next unless File.exist?(postfile_dir)
-        # Construct the directory the post will be in
-        post_dir = File.join(site.config['destination'], post.url)
-        # Copy postfiles to the directory created for this post
-        Dir[File.join(postfile_dir, '/*')].each{|pf| FileUtils.cp(pf, post_dir) }
+        postfile_dir = File.join(site.config['source'], '_postfiles', postfile_id)
+        
+        # Add a static file entry for each postfile, if any
+        Dir[File.join(postfile_dir, '/*')].each do |pf| 
+          site.static_files << PostFile.new(site, postfile_dir, post.url, File.basename(pf))
+        end
       end
     end
 
@@ -30,7 +37,7 @@ module Jekyll
 
     def initialize(tag_name, text, tokens)
       super
-      @text = text
+      @text = text.strip
     end
 
     def render(context)


### PR DESCRIPTION
Jekyll 0.9.0 introduced a mechanism for dealing with orphaned files. This was deleting the files that the postfiles plugin copied because Jekyll was not aware of them. I replaced the copy operation with creating instances of the Jekyll-internal `StaticFile` class.
