### PR TITLE
Renewed update to work with spaces in categories

### DIFF
--- a/_plugins/postfiles.rb
+++ b/_plugins/postfiles.rb
@@ -20,13 +20,13 @@ module Jekyll
 
       site.posts.each do |post|
         # Go back to the single-file post name
-        postfile_id = post.id.gsub(/[\s\w\/]*(\d{4})\/(\d\d)\/(\d\d)\/(.*)/, '\1-\2-\3-\4')
+        postfile_id = post.id.gsub(/[\s\w\/%]*(\d{4})\/(\d\d)\/(\d\d)\/(.*)/, '\1-\2-\3-\4')
         # Get the directory that files from this post would be in
         postfile_dir = File.join(site.config['source'], '_postfiles', postfile_id)
         
         # Add a static file entry for each postfile, if any
         Dir[File.join(postfile_dir, '/*')].each do |pf| 
-          site.static_files << PostFile.new(site, postfile_dir, post.url, File.basename(pf))
+          site.static_files << PostFile.new(site, postfile_dir, CGI.unescape(post.url), File.basename(pf))
         end
       end
     end


### PR DESCRIPTION
I updated `postfiles.rb` to work with posts that have a space in the category. Unlike the previous contributor, I noticed that spaces (and I assume other special characters) got escaped by Jekyll before storing in the `post.id`.  So for example "`this category`" would get an id starting with "`/this%20category/`" instead of "`/this category/`".

Did not check what caused this change in behaviour, assuming something changed in jekyll.

Tested it only on a small site of my own (not an experienced Ruby programmer yet), so please review carefully.
